### PR TITLE
os.path.join used to append to file paths

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/modisSuite/Downloader.py
+++ b/modisSuite/Downloader.py
@@ -35,10 +35,7 @@ class telecharger:
         self.delta=delta+1
         self.tuiles=tuiles
         self.session=requests.session()
-        if output[-1]=="/":
-            self.output=output
-        else:
-            self.output=output+"/"
+        self.output=output
         self.authentification(self.session)
         log.log('i',Nom,'Objet telecharger créer')
     def listeSource(self):
@@ -159,10 +156,10 @@ class telecharger:
     def telechargerUnfichier(self,addresse,nom):
         #Devrait vérifier l'existance d'un fichier sur le disque avant de le télécharger
         r=self.session.get(addresse)
-        with open(self.output+nom,'wb') as f:
+        with open(os.path.join(self.output, nom),'wb') as f:
             tailleFichier = int(r.headers['content-length'])#Ça va récupérer la taille du fichier à télécharger
             f.write(r.content)
-        reussi= tailleFichier==os.path.getsize(self.output+nom)
+        reussi= tailleFichier==os.path.getsize(os.path.join(self.output, nom))
         #Si le fichier télécharger a la taille théorique alors celle-ci est retournée.
         if reussi:
             return tailleFichier
@@ -211,7 +208,7 @@ class telecharger:
                         self.log.log('i',Nom,u'Le fichier '+fichier.name+u' du '+date+u' a une taille de '+str(r))
                     else:
                         self.log.log('e',Nom,u'Télécharment pour le fichier '+fichier.name+u' du '+date)
-                    with open(self.output+'listfile'+self.produit.upper()+'.txt','a') as f:
+                    with open(os.path.join(self.output, 'listfile'+self.produit.upper()+'.txt'),'a') as f:
                         f.write(fichier.name+'\n')
                 echecDeSuite=0
                 yield image


### PR DESCRIPTION
Hello, 
I was having issues with the downloader and I found that Downloader.py works more reliably if os.path.join is used to append files to a file path string instead of hardcoded slashes. These changes are reflected here.

-Tim